### PR TITLE
fix: remove the warning The GF_SECURITY_ADMIN_PASSWORD variable is not set

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     command:
       - "sh"
       - "-c"
-      - "grafana cli admin reset-admin-password ${GF_SECURITY_ADMIN_PASSWORD} && /run.sh"
+      - "grafana cli admin reset-admin-password $${GF_SECURITY_ADMIN_PASSWORD} && /run.sh"
     ports: 
       - 3100:3000 
   chromedp: 


### PR DESCRIPTION

*Issue #, if available:*

When running the docker compose command, there is one warning message `WARN[0000] The "GF_SECURITY_ADMIN_PASSWORD" variable is not set. Defaulting to a blank string`

*Description of changes:*

We could escape the variable if we want it to be expanded inside the container, using a double-dollar sign ($${envVariable}).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
